### PR TITLE
Add mandatory dependency on Visual Studio Core Editor

### DIFF
--- a/SolutionConfigurationName/ManifestVS15/source.extension.vsixmanifest
+++ b/SolutionConfigurationName/ManifestVS15/source.extension.vsixmanifest
@@ -24,6 +24,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="SolutionConfigurationNameMEF" Path="|SolutionConfigurationNameMEF|" />
   </Assets>
   <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
     <Prerequisite Id="Microsoft.Net.Component.4.6.1.SDK" Version="[15.0.26208.0,16.0)" DisplayName=".NET Framework 4.6.1 SDK" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Carlos Quintero states in his blogpost http://www.visualstudioextensibility.com/2017/01/10/its-time-to-change-the-vsix-manifest-of-your-extension-to-v3-for-visual-studio-2017-compatibility/ that an extension should depend on Visual Studio Core Editor at the very least.